### PR TITLE
Adjust `/course/filter/values/{filter}` endpoint to return names on top of just codes

### DIFF
--- a/app/routers/course.py
+++ b/app/routers/course.py
@@ -220,14 +220,20 @@ def search_course(
 
 
 @router.get("/filter/values/{filter}")
-def get_filter_values(session: SessionDep, filter: CourseFilter) -> list[str]:
-    column = None
+def get_filter_values(session: SessionDep, filter: CourseFilter) -> dict[str, str]:
+    code_col, title_col = None, None
     if filter is CourseFilter.subjects:
-        column = Subject.subj_code
+        code_col = Subject.subj_code
+        title_col = Subject.title
     elif filter is CourseFilter.attributes:
-        column = Attribute.attr_code
+        code_col = Attribute.attr_code
+        title_col = Attribute.title
     elif filter is CourseFilter.semesters:
-        column = Course_Offering.semester
+        result_scalars = (
+            session.execute(select(Course_Offering.semester).distinct()).scalars().all()
+        )
+        return {sem: sem.capitalize() for sem in result_scalars}
     else:
         return None
-    return session.execute(select(column).distinct()).scalars().all()
+    result_mappings = session.execute(select(code_col, title_col)).mappings().all()
+    return {row[code_col]: row[title_col] for row in result_mappings}

--- a/app/routers/course.py
+++ b/app/routers/course.py
@@ -234,6 +234,6 @@ def get_filter_values(session: SessionDep, filter: CourseFilter) -> dict[str, st
         )
         return {sem: sem.capitalize() for sem in result_scalars}
     else:
-        return None
+        return {}
     result_mappings = session.execute(select(code_col, title_col)).mappings().all()
     return {row[code_col]: row[title_col] for row in result_mappings}


### PR DESCRIPTION
## What?

Adjusts the `/course/filter/values/{filter}` endpoint to return mappings of codes to names instead of a list of just codes.

Closes #12.

## Why?

There is a part of the course planner website that hardcodes subject codes and names. This data can very easily change on a semester-to-semester basis and can easily grow outdated if it isn't dynamically fetched from an external source. In addition, including names to attribute and semester codes allows more flexibility on the frontend side should they ever want to be able to map those codes to names in the future.

## How?

Jack and I modified the select statements `/course/filter/values/{filter}` endpoint function in the `course.py` router.

## Testing?

It works with Postman.

## Anything Else?

Have a nice day.