### PR TITLE
Rename `deptFilters` to `subjFilters` in course search endpoint

### DIFF
--- a/app/routers/course.py
+++ b/app/routers/course.py
@@ -141,12 +141,12 @@ def search_course_query(
 def search_course(
     session: SessionDep,
     searchPrompt: str | None = None,
-    deptFilters: str | None = None,
+    subjFilters: str | None = None,
     attrFilters: str | None = None,
     semFilters: str | None = None,
 ) -> list[dict[str, str | int | list[str]]]:
     # FastAPI does not support list query parameters
-    dept_filters = deptFilters.split(",") if deptFilters else None
+    dept_filters = subjFilters.split(",") if subjFilters else None
     attr_filters = attrFilters.split(",") if attrFilters else None
     sem_filters = semFilters.split(",") if semFilters else None
     if not (dept_filters or attr_filters or sem_filters):


### PR DESCRIPTION
## What?

Renames the `deptFilters` query parameter in the `/course/search` endpoint to `subjFilters`.

Closes #15.

## Why?

In our last change to the API, the "departments" filter value in another endpoint was renamed to "subjects". This change keeps naming consistent across the API. On top of that, subjects are different from departments as far as SIS is concerned.

## How?

I changed two lines.

## Testing?

It works through Postman.

## Anything Else?

Please, I just changed two lines.